### PR TITLE
Anm (e)xtract and decompilation options

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -5,7 +5,7 @@ use crate::game::Game;
 use crate::diagnostic::{RootEmitter, IntoDiagnostics};
 use crate::error::ErrorReported;
 use crate::context::{CompilerContext, Scope};
-use crate::passes::DecompileKind;
+use crate::llir::DecompileOptions;
 
 /// Front-end API of `truth`, for direct use by `truth`'s various entry point functions, as well
 /// as by unit tests.
@@ -138,17 +138,17 @@ impl Truth<'_> {
         crate::StdFile::compile_from_ast(game, ast, &mut self.ctx)
     }
 
-    pub fn decompile_anm(&mut self, game: Game, middle: &crate::AnmFile, decompile_kind: DecompileKind) -> Result<ast::ScriptFile, ErrorReported> {
-        crate::AnmFile::decompile_to_ast(middle, game, &mut self.ctx, decompile_kind)
+    pub fn decompile_anm(&mut self, game: Game, middle: &crate::AnmFile, decompile_options: &DecompileOptions) -> Result<ast::ScriptFile, ErrorReported> {
+        crate::AnmFile::decompile_to_ast(middle, game, &mut self.ctx, decompile_options)
     }
-    pub fn decompile_msg(&mut self, game: Game, middle: &crate::MsgFile, decompile_kind: DecompileKind) -> Result<ast::ScriptFile, ErrorReported> {
-        crate::MsgFile::decompile_to_ast(middle, game, &mut self.ctx, decompile_kind)
+    pub fn decompile_msg(&mut self, game: Game, middle: &crate::MsgFile, decompile_options: &DecompileOptions) -> Result<ast::ScriptFile, ErrorReported> {
+        crate::MsgFile::decompile_to_ast(middle, game, &mut self.ctx, decompile_options)
     }
     pub fn decompile_mission(&mut self, game: Game, middle: &crate::MissionMsgFile) -> Result<ast::ScriptFile, ErrorReported> {
         crate::MissionMsgFile::decompile_to_ast(middle, game, &mut self.ctx)
     }
-    pub fn decompile_std(&mut self, game: Game, middle: &crate::StdFile, decompile_kind: DecompileKind) -> Result<ast::ScriptFile, ErrorReported> {
-        crate::StdFile::decompile_to_ast(middle, game, &mut self.ctx, decompile_kind)
+    pub fn decompile_std(&mut self, game: Game, middle: &crate::StdFile, decompile_options: &DecompileOptions) -> Result<ast::ScriptFile, ErrorReported> {
+        crate::StdFile::decompile_to_ast(middle, game, &mut self.ctx, decompile_options)
     }
 }
 

--- a/src/cli_def.rs
+++ b/src/cli_def.rs
@@ -555,16 +555,20 @@ mod cli {
     }
 
     pub fn decompile_options() -> impl CliArg<Value=DecompileOptions> {
-        let no_intrinsics = opts::Flag {
-            short: "", long: "no-intrinsics",
-            help: "prevent recognition of special opcodes, so that every instruction decompiles uniformly into a simple function call",
-        };
         let no_blocks = opts::Flag {
             short: "", long: "no-blocks",
             help: "prevent decompilation of loops and other control flow",
         };
-        no_intrinsics.zip(no_blocks).map(|(no_intrinsics, no_blocks)| DecompileOptions {
-            intrinsics: !no_intrinsics, blocks: !no_blocks,
+        let no_intrinsics = opts::Flag {
+            short: "", long: "no-intrinsics",
+            help: "prevent recognition of special opcodes, so that every instruction decompiles uniformly into a simple function call",
+        };
+        let no_arguments = opts::Flag {
+            short: "", long: "no-arguments",
+            help: "prevent decompilation of arguments, leaving all instructions in their most raw format possible. A last resort for troublesome files",
+        };
+        no_intrinsics.zip(no_blocks).zip(no_arguments).map(|((no_intrinsics, no_blocks), no_arguments)| DecompileOptions {
+            intrinsics: !no_intrinsics, blocks: !no_blocks, arguments: !no_arguments,
         })
     }
 

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -27,6 +27,8 @@ impl Diagnostic {
     pub fn error() -> Self { Diagnostic { imp: CsDiagnostic::error(), unspanned_prefix: String::new() } }
     /// Construct with warning severity.  Generally you use the [`warning!`] macro instead.
     pub fn warning() -> Self { Diagnostic { imp: CsDiagnostic::warning(), unspanned_prefix: String::new() } }
+    /// Construct with info severity.  Generally you use the [`info!`] macro instead.
+    pub fn info() -> Self { Diagnostic { imp: CsDiagnostic::note(), unspanned_prefix: String::new() } }
 
     pub fn code(&mut self, code: &'static str) -> &mut Self {
         self.imp.code = Some(code.into());

--- a/src/image/color.rs
+++ b/src/image/color.rs
@@ -43,6 +43,15 @@ impl ColorFormat {
         }
     }
 
+    pub fn bytes_per_pixel(&self) -> usize {
+        match self {
+            ColorFormat::Argb8888 => Argb8888::BYTES_PER_PIXEL,
+            ColorFormat::Rgb565 => Rgb565::BYTES_PER_PIXEL,
+            ColorFormat::Argb4444 => Argb4444::BYTES_PER_PIXEL,
+            ColorFormat::Gray8 => Gray8::BYTES_PER_PIXEL,
+        }
+    }
+
     pub fn transcode_to_argb_8888(&self, bytes: &[u8]) -> Vec<u8> {
         match self {
             ColorFormat::Argb8888 => bytes.to_vec(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ pub mod eclmap;
 pub use context::{Scope, CompilerContext};
 pub mod context;
 
-pub use passes::DecompileKind;
 pub mod passes;
 
 pub use ident::{Ident, ParseIdentError};
@@ -54,6 +53,7 @@ mod image;
 pub use io::Fs;
 pub mod io;
 
+pub use llir::DecompileOptions;
 pub mod llir;
 
 pub mod pseudo;

--- a/src/llir/mod.rs
+++ b/src/llir/mod.rs
@@ -262,6 +262,7 @@ pub enum IntrinsicInstrKind {
     CondJmp(ast::BinopKind, ScalarType),
 }
 
+#[derive(Default)]
 pub struct IntrinsicInstrs {
     intrinsic_opcodes: HashMap<IntrinsicInstrKind, u16>,
     opcode_intrinsics: HashMap<u16, IntrinsicInstrKind>,

--- a/src/llir/mod.rs
+++ b/src/llir/mod.rs
@@ -15,7 +15,7 @@ mod abi;
 pub use lower::lower_sub_ast_to_instrs;
 mod lower;
 
-pub use raise::Raiser;
+pub use raise::{Raiser, DecompileOptions};
 mod raise;
 
 /// The lowest level representation of an instruction that is common between all games.

--- a/src/llir/raise.rs
+++ b/src/llir/raise.rs
@@ -123,7 +123,6 @@ fn raise_instrs_to_sub_ast(
         true => instr_format.intrinsic_instrs(),
         false => Default::default(),
     };
-    eprintln!("{:?}", raiser.options);
 
     for (&offset, instr) in zip!(&instr_offsets, &script) {
         if let Some(label) = offset_labels.get(&offset) {

--- a/src/util_macros.rs
+++ b/src/util_macros.rs
@@ -155,6 +155,12 @@ macro_rules! warning {
     ($($arg:tt)+) => { $crate::_diagnostic!(@warning, $($arg)+) };
 }
 
+/// Generates a [`crate::diagnostic::Diagnostic`] of severity `info`.
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)+) => { $crate::_diagnostic!(@info, $($arg)+) };
+}
+
 #[test]
 fn error_macro_examples() {
     use crate::ast;

--- a/tests/expr_compile.rs
+++ b/tests/expr_compile.rs
@@ -250,7 +250,7 @@ fn _run_randomized_test(truth: &mut Truth, vars: &[Var], text: &str) -> Result<(
     let ctx = truth.ctx();
     let old_stmts = parsed_block.0;
     let instrs = llir::lower_sub_ast_to_instrs(&instr_format, &old_stmts, ctx)?;
-    let mut new_block = ast::Block(llir::Raiser::new(&ctx.emitter).raise_instrs_to_sub_ast(&emitter, &instr_format, &instrs, &ctx.defs)?);
+    let mut new_block = ast::Block(llir::Raiser::new(&ctx.emitter, &Default::default()).raise_instrs_to_sub_ast(&emitter, &instr_format, &instrs, &ctx.defs)?);
     truth::passes::resolve_names::aliases_to_raw(&mut new_block, ctx)?;
 
     let mut old_vm = base_vm.clone();


### PR DESCRIPTION
* `truanm extract` (`truanm x` for short).  I did this weeks ago but must have gotten pulled away from this shortly before merging?
* `--no-blocks`, `--no-intrinsics`, `--no-arguments` to disable various parts of decompilation. (needed this to update the stats page on the website)

Closes #43
Closes #32